### PR TITLE
Force lucene version

### DIFF
--- a/com.dubture.indexing.core/META-INF/MANIFEST.MF
+++ b/com.dubture.indexing.core/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-Vendor: http://github.com/pulse00
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources,
  org.eclipse.ui,
- org.apache.lucene.core;bundle-version="2.9.1",
+ org.apache.lucene.core;bundle-version="[2.9.1, 3.0.0)",
  com.google.gson
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy


### PR DESCRIPTION
This manifest force bundle version lover than 3.0 (incompatible for now). Please merge ASAP!

Required for pulse00/Symfony-2-Eclipse-Plugin#229